### PR TITLE
Update purejscarousel.3.0.0.js

### DIFF
--- a/purejscarousel.3.0.0.js
+++ b/purejscarousel.3.0.0.js
@@ -558,6 +558,9 @@
       }
       this.carousel.removeChild(this.slidesContainer);
 
+      this.btnNext.replaceWith(this.btnNext.cloneNode(true));
+      this.btnPrev.replaceWith(this.btnPrev.cloneNode(true));
+
       this.minPos = null;
       this.slidesToShow = null;
       this.maxIndex = null;


### PR DESCRIPTION
Adding deepclone for buttons prev and next in destroy function to remove Events Listener.
Without this, events keep being fired even if carousel has been destroyed (and created error if carousel is initialised again)